### PR TITLE
Allow to specify additional sidecar containers and environment variables mapped from Secret or ConfigMap

### DIFF
--- a/active-mq/README.md
+++ b/active-mq/README.md
@@ -82,6 +82,8 @@ helm delete my-activemq
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `tolerations` | Tolerations for pod assignment | `[]` |
 | `affinity` | Affinity for pod assignment | `{}` |
+| `extraEnvFrom` | Additional environment variables mapped from Secret or ConfigMap | `""` |
+| `extraContainers` | Additional sidecar containers, e.g. for a database proxy, such as Google's cloudsql-proxy | `""` |
 
 ### Service Settings
 

--- a/active-mq/templates/statefulset.yaml
+++ b/active-mq/templates/statefulset.yaml
@@ -27,6 +27,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ include "active-mq.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -158,7 +159,10 @@ spec:
               value: {{ $value | quote }}
             {{- end }}
             {{- end }} 
-          
+          envFrom:
+            {{- with .Values.extraEnvFrom }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - mountPath: /var/lib/artemis-instance/etc-override/broker.xml
               name: artemis-config-volume
@@ -170,7 +174,9 @@ spec:
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-        
+        {{- with .Values.extraContainers }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
         {{- if .Values.monitoring.jmx.enabled }}
         - name: jmx-exporter
           image: {{ .Values.monitoring.jmx.exporter.image | default "bitnami/jmx-exporter:1.1.0" }}

--- a/active-mq/values.yaml
+++ b/active-mq/values.yaml
@@ -76,6 +76,18 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+# Additional environment variables mapped from Secret or ConfigMap
+extraEnvFrom: ""
+
+# Additional sidecar containers as a YAML string (e.g., for a database proxy like Google's cloudsql-proxy).
+# Example:
+#   extraContainers: |
+#     - name: cloud-sql-proxy
+#       image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.18
+#       args:
+#         - "project:region:instance"
+extraContainers: ""
+
 #######################
 # Service Settings   #
 #######################


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure extra sidecar containers for ActiveMQ deployments.
  * Map environment variables from ConfigMap/Secret into pods via new envFrom support.
  * Specify the pod service account used by ActiveMQ.

* **Documentation**
  * README and configuration defaults updated to document the new pod settings (extra containers and envFrom).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->